### PR TITLE
Add Client-Init Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ composer.lock
 *.iml
 .phpunit.result.cache
 node_modules
+phpunit.xml
 

--- a/src/Cidaas.php
+++ b/src/Cidaas.php
@@ -13,24 +13,24 @@ use Psr\Http\Message\ResponseInterface;
  * @package Cidaas\OAuth2\Client\Provider
  */
 class Cidaas {
-    private static $well_known_uri = "/.well-known/openid-configuration";
-    private static $requestIdUri = '/authz-srv/authrequest/authz/generate';
-    private static $getRegistrationSetupUri = '/registration-setup-srv/public/list';
-    private static $registerSdkUri = '/users-srv/register';
-    private static $loginSdkUri = '/login-srv/login';
-    private static $changePasswordUri = '/users-srv/changepassword';
-    private static $updateProfileUriPrefix = '/users-srv/user/profile/';
-    private static $initiateResetPasswordUri = '/users-srv/resetpassword/initiate';
-    private static $handleResetPasswordUri = '/users-srv/resetpassword/validatecode';
-    private static $resetPasswordUri = '/users-srv/resetpassword/accept';
+    private static string $well_known_uri = "/.well-known/openid-configuration";
+    private static string $requestIdUri = '/authz-srv/authrequest/authz/generate';
+    private static string $getRegistrationSetupUri = '/registration-setup-srv/public/list';
+    private static string $registerSdkUri = '/users-srv/register';
+    private static string $loginSdkUri = '/login-srv/login';
+    private static string $changePasswordUri = '/users-srv/changepassword';
+    private static string $updateProfileUriPrefix = '/users-srv/user/profile/';
+    private static string $initiateResetPasswordUri = '/users-srv/resetpassword/initiate';
+    private static string $handleResetPasswordUri = '/users-srv/resetpassword/validatecode';
+    private static string $resetPasswordUri = '/users-srv/resetpassword/accept';
 
     private $openid_config;
-    private $baseUrl = "";
-    private $clientId = "";
-    private $clientSecret = "";
-    private $redirectUri = "";
-    private $handler;
-    private $debug = false;
+    private string $baseUrl = "";
+    private string $clientId = "";
+    private string $clientSecret = "";
+    private string $redirectUri = "";
+    private HandlerStack $handler;
+    private bool $debug = false;
 
     /**
      * Cidaas constructor.
@@ -66,7 +66,7 @@ class Cidaas {
      * @param string $acceptLanguage for the language. defaults to "en-GB"
      * @return PromiseInterface promise with the requestId or error
      */
-    public function getRequestId($scope = 'openid', $responseType = 'code', string $acceptLanguage = 'en-GB'): PromiseInterface {
+    public function getRequestId(string $scope = 'openid', string $responseType = 'code', string $acceptLanguage = 'en-GB'): PromiseInterface {
         $client = $this->createClient();
 
         $params = [
@@ -186,7 +186,7 @@ class Cidaas {
 
     /**
      * Performs a redirect to the hosted login page.
-     * @param string scope for login
+     * @param string $scope for login
      * @param array $queryParameters (optional) optionally adds more query parameters to the url.
      * @throws \LogicException if no loginUrl has been set
      */
@@ -257,7 +257,6 @@ class Cidaas {
      * @return PromiseInterface promise with access token or error
      */
     public function getAccessToken(string $grantType, string $code = '', string $refreshToken = ''): PromiseInterface {
-        $params = [];
         if ($grantType === GrantType::AuthorizationCode) {
             if (empty($code)) {
                 throw new \InvalidArgumentException('code must not be empty in authorization_code flow');

--- a/src/Cidaas.php
+++ b/src/Cidaas.php
@@ -6,7 +6,9 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\RequestOptions;
+use LogicException;
 use Psr\Http\Message\ResponseInterface;
+use UnexpectedValueException;
 
 /**
  * Cidaas connector.
@@ -188,7 +190,7 @@ class Cidaas {
      * Performs a redirect to the hosted login page.
      * @param string $scope for login
      * @param array $queryParameters (optional) optionally adds more query parameters to the url.
-     * @throws \LogicException if no loginUrl has been set
+     * @throws LogicException if no loginUrl has been set
      */
     public function loginWithBrowser(string $scope = 'openid profile offline_access', array $queryParameters = array()) {
         $loginUrl = $this->openid_config['authorization_endpoint'];

--- a/src/Cidaas.php
+++ b/src/Cidaas.php
@@ -522,7 +522,7 @@ class Cidaas {
     }
 
     private function validate($param, $name) {
-        if (!isset($param) || empty($param)) {
+        if (empty($param)) {
             throw new \InvalidArgumentException($name . ' is not specified');
         }
     }

--- a/src/Cidaas.php
+++ b/src/Cidaas.php
@@ -35,20 +35,20 @@ class Cidaas {
     /**
      * Cidaas constructor.
      * @param string $baseUrl of cidaas server
-     * @param string $cliendId of cidaas application
+     * @param string $clientId of cidaas application
      * @param string $clientSecret of cidaas application
      * @param string $redirectUri to redirect to after login
      * @param HandlerStack|null $handler (optional) for http requests
      * @param bool $debug (optional) to enable debugging
      */
-    public function __construct(string $baseUrl, string $cliendId, string $clientSecret, string $redirectUri, HandlerStack $handler = null, bool $debug = false) {
-        $this->validate($baseUrl, '$baseUrl');
-        $this->validate($cliendId, '$cliendId');
-        $this->validate($clientSecret, '$clientSecret');
-        $this->validate($redirectUri, '$redirectUri');
+    public function __construct(string $baseUrl, string $clientId, string $clientSecret, string $redirectUri, HandlerStack $handler = null, bool $debug = false) {
+        $this->validate($baseUrl, 'Base URL');
+        $this->validate($clientId, 'Client-ID');
+        $this->validate($clientSecret, 'Client-Secret');
+        $this->validate($redirectUri, 'Redirect URL');
 
         $this->baseUrl = rtrim($baseUrl, "/");
-        $this->clientId = $cliendId;
+        $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
         $this->redirectUri = $redirectUri;
         if (isset($handler)) {

--- a/src/Cidaas.php
+++ b/src/Cidaas.php
@@ -210,6 +210,7 @@ class Cidaas {
      * @throws LogicException if no loginUrl has been set
      */
     public function loginWithBrowser(string $scope = 'openid profile offline_access', array $queryParameters = array()) {
+        $this->initClient();
         $loginUrl = $this->openid_config['authorization_endpoint'];
         $loginUrl .= '?client_id=' . $this->clientId;
         $loginUrl .= '&response_type=code';

--- a/src/Cidaas.php
+++ b/src/Cidaas.php
@@ -26,7 +26,7 @@ class Cidaas {
     private static string $handleResetPasswordUri = '/users-srv/resetpassword/validatecode';
     private static string $resetPasswordUri = '/users-srv/resetpassword/accept';
 
-    private $openid_config;
+    private array $openid_config;
     private string $baseUrl = "";
     private string $clientId = "";
     private string $clientSecret = "";
@@ -309,9 +309,8 @@ class Cidaas {
             throw new \InvalidArgumentException('invalid grant type');
         }
 
-        $url = $this->openid_config["token_endpoint"];
-
         $client = $this->createClient();
+        $url = $this->openid_config["token_endpoint"];
         $responsePromise = $client->requestAsync('POST', $url, ['form_params' => $params]);
         return $responsePromise->then(function (ResponseInterface $response) {
             $body = $response->getBody();
@@ -326,12 +325,12 @@ class Cidaas {
      * @return PromiseInterface promise with user profile or error
      */
     public function getUserProfile(string $accessToken, string $sub = ""): PromiseInterface {
+        $client = $this->createClient();
         $url = $this->openid_config["userinfo_endpoint"];
         if (!empty($sub)) {
             $url .= "/" . $sub;
         }
 
-        $client = $this->createClient();
         $responsePromise = $client->requestAsync('POST', $url, [
             "headers" => [
                 "Authorization" => "Bearer " . $accessToken,
@@ -508,13 +507,13 @@ class Cidaas {
      * @return PromiseInterface promise with success (redirect) or error message
      */
     public function logout(string $accessToken, string $postLogoutUri = ""): PromiseInterface {
+        $client = $this->createClient();
         $url = $this->openid_config["end_session_endpoint"] . "?access_token_hint=" . $accessToken;
 
         if (!empty($postLogoutUri)) {
             $url .= "&post_logout_redirect_uri=" . urlencode($postLogoutUri);
         }
 
-        $client = $this->createClient();
         return $client->requestAsync('POST', $url, ['allow_redirects' => false]);
     }
 

--- a/tests/LoginWithBrowserTest.php
+++ b/tests/LoginWithBrowserTest.php
@@ -14,7 +14,6 @@ final class LoginWithBrowserTest extends AbstractCidaasTestParent {
     }
 
     public function test_loginWithBrowser_withRequestId_redirectsToLoginPage() {
-        $this->mock->reset();
         $this->mock->append(new Response(302, ['location' => self::$LOGIN_URL]));
 
         $this->provider->loginWithBrowser();


### PR DESCRIPTION
This change adds a new initClient() method and moves the fetching of the openid configuration from the constructor to the initClient() method. This speeds up sites, which instantiates an Cidaas-claas on every request, but don't use the Cidaas class.

Before any URL is read from the configuration array, the initClient() method has to be called. Added this to every method.

When you merge this, pleases tag a new version.